### PR TITLE
Add basic task object

### DIFF
--- a/app/Domain/Entity/Task/State.php
+++ b/app/Domain/Entity/Task/State.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Entity\Task;
+
+enum State
+{
+    case OPEN;
+    case CLOSED;
+}

--- a/app/Domain/Entity/Task/Task.php
+++ b/app/Domain/Entity/Task/Task.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Entity\Task;
+
+use App\Domain\Support\UUID;
+
+/**
+ * A Task is a unit of work that should be completed.
+ */
+final class Task
+{
+    /**
+     * Unique identifier
+     */
+    public readonly UUID $id;
+
+    private string $textField;
+
+    /**
+     * Short description of the task
+     */
+    public string $text {
+        get {
+            return $this->textField;
+        }
+    }
+
+    private State $stateField;
+
+    /**
+     * Current state of the task
+     */
+    public State $state {
+        get {
+            return $this->stateField;
+        }
+    }
+
+    public function __construct(UUID $id, string $text)
+    {
+        $this->id = $id;
+        $this->textField = $text;
+        $this->stateField = State::OPEN;
+    }
+}

--- a/app/Domain/Support/UUID.php
+++ b/app/Domain/Support/UUID.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Support;
+
+use Ramsey\Uuid\UuidFactory;
+use Ramsey\Uuid\UuidInterface;
+
+final class UUID extends \Ramsey\Uuid\Uuid
+{
+    private UuidInterface $concrete;
+
+    public static function generate(): UUID
+    {
+        $concrete = new UuidFactory()->uuid4();
+
+        return new self($concrete);
+    }
+
+    /**
+     * @phpstan-impure
+     */
+    public static function fromString(string $string): UUID
+    {
+        $concrete = new UuidFactory()->fromString($string);
+
+        return new self($concrete);
+    }
+
+    public function toString(): string
+    {
+        return (string) $this;
+    }
+
+    public function __toString(): string
+    {
+        return (string) $this->concrete;
+    }
+
+    private function __construct(UuidInterface $concrete)
+    {
+        $this->concrete = $concrete;
+    }
+}

--- a/tests/Unit/Task/TaskTest.php
+++ b/tests/Unit/Task/TaskTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Task;
+
+use App\Domain\Entity\Task\State;
+use App\Domain\Entity\Task\Task;
+use App\Domain\Support\UUID;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+#[CoversClass(Task::class)]
+final class TaskTest extends TestCase
+{
+    #[Test]
+    public function tasks_are_created_open(): void
+    {
+        $task = new Task(UUID::generate(), 'Basic Task');
+
+        $this->assertSame(State::OPEN, $task->state);
+    }
+
+    #[Test]
+    public function attributes_match_constructed_args(): void
+    {
+        $uuid = UUID::generate();
+        $text = 'Basic Task';
+
+        $task = new Task($uuid, $text);
+
+        $this->assertSame($uuid->toString(), $task->id->toString());
+        $this->assertSame($text, $task->text);
+    }
+
+    #[Test]
+    public function attributes_cannot_be_directly_modified(): void
+    {
+        $uuid = UUID::generate();
+        $text = 'Basic Task';
+
+        $task = new Task($uuid, $text);
+
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessageMatches('/Property ([^ ]+) is read-only/');
+        $task->text = 'Updated Task'; // @phpstan-ignore-line
+    }
+}

--- a/tests/Unit/UUID/UUIDTest.php
+++ b/tests/Unit/UUID/UUIDTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\UUID;
+
+use App\Domain\Support\UUID;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+#[CoversClass(UUID::class)]
+final class UUIDTest extends TestCase
+{
+    #[Test]
+    public function generated_uuid_is_valid_uuid_v4(): void
+    {
+        $uuidv4Pattern = '/^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i';
+
+        $this->assertTrue((bool) preg_match($uuidv4Pattern, UUID::generate()->toString()));
+    }
+
+    #[Test]
+    public function generated_uuids_are_different(): void
+    {
+        $set = [];
+        $numGenerations = 10;
+        for ($i = 0; $i < $numGenerations; $i++) {
+            $uuid = UUID::generate()->toString();
+            $this->assertFalse(isset($set[$uuid]));
+            $set[$uuid] = true;
+        }
+    }
+
+    #[Test]
+    public function rehydration_from_string(): void
+    {
+        $origin = UUID::generate();
+        $rehydrated = UUID::fromString($origin->toString());
+
+        $this->assertSame($origin->toString(), $rehydrated->toString());
+    }
+}


### PR DESCRIPTION
This PR creates the first Entity in the system, the Task. 

This initial implementation is absurdly simple, and allows the creation of a Task object with a user specified piece of text associated with it. The Task is assigned a randomly generated UUID and is created in the OPEN state. The attributes of the Task are publicly readable, but are currently immutable via direct modification from outside the object. The ID is totally immutable as the primary identifier for the object's identity.