### PR TITLE
Move attributes into value object and create factory

### DIFF
--- a/app/Domain/Entity/Task/Attributes.php
+++ b/app/Domain/Entity/Task/Attributes.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Entity\Task;
+
+final class Attributes
+{
+    public function __construct(
+        public string $text,
+        public State $state,
+    ) {}
+}

--- a/app/Domain/Entity/Task/Task.php
+++ b/app/Domain/Entity/Task/Task.php
@@ -12,36 +12,25 @@ use App\Domain\Support\UUID;
 final class Task
 {
     /**
-     * Unique identifier
-     */
-    public readonly UUID $id;
-
-    private string $textField;
-
-    /**
      * Short description of the task
      */
     public string $text {
         get {
-            return $this->textField;
+            return $this->attributes->text;
         }
     }
-
-    private State $stateField;
 
     /**
      * Current state of the task
      */
     public State $state {
         get {
-            return $this->stateField;
+            return $this->attributes->state;
         }
     }
 
-    public function __construct(UUID $id, string $text)
-    {
-        $this->id = $id;
-        $this->textField = $text;
-        $this->stateField = State::OPEN;
-    }
+    public function __construct(
+        public readonly UUID $id,
+        private Attributes $attributes,
+    ) {}
 }

--- a/app/Domain/Factory/TaskFactory.php
+++ b/app/Domain/Factory/TaskFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Factory;
+
+use App\Domain\Entity\Task\Attributes;
+use App\Domain\Entity\Task\State;
+use App\Domain\Entity\Task\Task;
+use App\Domain\Support\UUID;
+
+final class TaskFactory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'text' => fake()->text(32),
+            'state' => State::OPEN,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function make(?UUID $id = null, array $attributes = []): Task
+    {
+        $mergedAttributes = array_merge($this->definition(), $attributes);
+
+        return new Task($id ?? UUID::generate(), new Attributes(...$mergedAttributes));
+    }
+}

--- a/tests/Unit/Task/TaskTest.php
+++ b/tests/Unit/Task/TaskTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Task;
 
 use App\Domain\Entity\Task\State;
 use App\Domain\Entity\Task\Task;
+use App\Domain\Factory\TaskFactory;
 use App\Domain\Support\UUID;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -17,7 +18,7 @@ final class TaskTest extends TestCase
     #[Test]
     public function tasks_are_created_open(): void
     {
-        $task = new Task(UUID::generate(), 'Basic Task');
+        $task = (new TaskFactory)->make();
 
         $this->assertSame(State::OPEN, $task->state);
     }
@@ -28,7 +29,7 @@ final class TaskTest extends TestCase
         $uuid = UUID::generate();
         $text = 'Basic Task';
 
-        $task = new Task($uuid, $text);
+        $task = (new TaskFactory)->make(id: $uuid, attributes: ['text' => $text]);
 
         $this->assertSame($uuid->toString(), $task->id->toString());
         $this->assertSame($text, $task->text);
@@ -37,10 +38,7 @@ final class TaskTest extends TestCase
     #[Test]
     public function attributes_cannot_be_directly_modified(): void
     {
-        $uuid = UUID::generate();
-        $text = 'Basic Task';
-
-        $task = new Task($uuid, $text);
+        $task = (new TaskFactory)->make();
 
         $this->expectException(\Error::class);
         $this->expectExceptionMessageMatches('/Property ([^ ]+) is read-only/');


### PR DESCRIPTION
This PR splits the internal non-id attributes for a Task into an internal value object, and creates a Factory to assist in the creation of Tasks. This simplifies the code for the Task object to only need to define which attributes should be publicly readable (while preventing external modifications), and allows for a relatively simple syntax to the factory when specifying attributes.

Currently there is no validation for attributes passed into the factory, but the creation of the Attribute value object will fail with an unknown named parameter error. Static type hinting may not be possible without excessive boilerplate.