### PR TITLE
Patches to support local development environment

### DIFF
--- a/.devscripts/composer
+++ b/.devscripts/composer
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [ "$EUID" = "0" ]; then
+  runuser -u sail -- /usr/bin/composer "$@"
+else
+  /usr/bin/composer "$@"
+fi

--- a/.devscripts/php
+++ b/.devscripts/php
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [ "$EUID" = "0" ]; then
+  runuser -u sail -- /usr/bin/php "$@"
+else
+  /usr/bin/php "$@"
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 # Ignore OS junk
 Thumbs.db
 
+# Exception - devscripts
+!.devscripts
+
 # Exceptions - git / github
 !.gitattributes
 !.github

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
         volumes:
             - '.:/var/www/html'
             - './.coverage:/opt/phpstorm-coverage'
+            - './.devscripts/composer:/usr/local/bin/composer'
+            - './.devscripts/php:/usr/local/bin/php'
         networks:
             - sail
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
             IGNITION_LOCAL_SITES_PATH: '${PWD}'
         volumes:
             - '.:/var/www/html'
+            - './.coverage:/opt/phpstorm-coverage'
         networks:
             - sail
 networks:


### PR DESCRIPTION
This PR adds some scripts and configs to ensure that IDE tooling interacts with the local development environment correctly. 

In particular, some IDEs will execute docker commands as the root user instead of the local container user. By mounting a wrapper script in the local bin directory of the container, we can ensure that if the script is executed by the root user we de-escalate to the local container user before proceeding.

When code-coverage reports are generated by tests, they are written inside the container, but need a location to be read by the IDE to apply coverage data in the interface. The simplest way to accomplish this is mounting a local directory into the container where it expects the coverage reports to be written.