### PR TITLE
Add methods to allow closing and re-opening tasks

### DIFF
--- a/app/Domain/Entity/StateTransitionException.php
+++ b/app/Domain/Entity/StateTransitionException.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Entity;
+
+final class StateTransitionException extends \LogicException {}

--- a/app/Domain/Entity/Task/Task.php
+++ b/app/Domain/Entity/Task/Task.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Domain\Entity\Task;
 
+use App\Domain\Entity\StateTransitionException;
 use App\Domain\Support\UUID;
 
 /**
@@ -33,4 +34,30 @@ final class Task
         public readonly UUID $id,
         private Attributes $attributes,
     ) {}
+
+    /**
+     * Close the task.
+     *
+     * @throws \App\Domain\Entity\StateTransitionException If the task is already closed.
+     */
+    public function close(): void
+    {
+        if ($this->attributes->state === State::CLOSED) {
+            throw new StateTransitionException('Task is already closed.');
+        }
+        $this->attributes->state = State::CLOSED;
+    }
+
+    /**
+     * Re-open the task.
+     *
+     * @throws \App\Domain\Entity\StateTransitionException If the task is already open.
+     */
+    public function reopen(): void
+    {
+        if ($this->attributes->state === State::OPEN) {
+            throw new StateTransitionException('Task is already open.');
+        }
+        $this->attributes->state = State::OPEN;
+    }
 }


### PR DESCRIPTION
This PR adds some simple methods to the Task object which allows manipulating the state of the Task between OPEN and CLOSED. 

There are business rules embedded in the methods which prevent changing the state to itself, and a new StateTransitionException is introduced to be triggered when this occurs. Tests have been added to ensure these rules are correctly implemented.